### PR TITLE
Remove sqrt

### DIFF
--- a/src/DehazingCE.cpp
+++ b/src/DehazingCE.cpp
@@ -3,6 +3,8 @@
 #include "DehazingCE.h"
 #include "Helper.hpp"
 
+constexpr float SQRT_3 = 1.733f;
+
 dehazing::dehazing(int nW, int nH, int nBits, int nABlockSize, int nTBlockSize, float fTransInit, bool bPrevFlag, bool bPosFlag, float fL1, float fL2, int nGBlockSize)
 {
     width = nW;
@@ -314,7 +316,7 @@ float dehazing::NFTrsEstimationColor(const T* pnImageR, const T* pnImageG, const
 template <typename T>
 void dehazing::AirlightEstimation(const T* src, int width, int height, int stride)
 {
-    int nMinDistance = peak * peak * 3;
+    int nMinDistance = (int)(peak * SQRT_3);
 
     int nMaxIndex;
     double dpScore[3];
@@ -486,8 +488,9 @@ void dehazing::AirlightEstimation(const T* src, int width, int height, int strid
             {
                 const auto pos = (j * width + i) * 3;
                 // peak-r, peak-g, peak-b
-                int nDistance = (peak - src[pos]) * (peak - src[pos]) + (peak - src[pos + 1]) * (peak - src[pos + 1]) +
-                                (peak - src[pos + 2]) * (peak - src[pos + 2]);
+                int nDistance = (int)std::sqrt((float)(peak - src[pos]) * (peak - src[pos]) +
+                                               (float)(peak - src[pos + 1]) * (peak - src[pos + 1]) +
+                                               (float)(peak - src[pos + 2]) * (peak - src[pos + 2]));
                 if (nMinDistance > nDistance)
                 {
                     // atmospheric light value

--- a/src/DehazingCE.cpp
+++ b/src/DehazingCE.cpp
@@ -340,7 +340,7 @@ void dehazing::AirlightEstimation(const T* src, int width, int height, int strid
     memcpy(iplLowerLeft,  src + half_w * half_h * 6, half_w * half_h * 3 * sizeof(T));
     memcpy(iplLowerRight, src + half_w * half_h * 9, half_w * half_h * 3 * sizeof(T));
 
-    if (height * width > 200)
+    if (height * width > ABlockSize)
     {
         // compute the mean and std-dev in the sub-block
         T* iplR = new T[half_h * half_w];

--- a/src/DehazingCE.cpp
+++ b/src/DehazingCE.cpp
@@ -3,7 +3,7 @@
 #include "DehazingCE.h"
 #include "Helper.hpp"
 
-dehazing::dehazing(int nW, int nH, int nBits, int nTBlockSize, float fTransInit, bool bPrevFlag, bool bPosFlag, float fL1, float fL2, int nGBlockSize)
+dehazing::dehazing(int nW, int nH, int nBits, int nABlockSize, int nTBlockSize, float fTransInit, bool bPrevFlag, bool bPosFlag, float fL1, float fL2, int nGBlockSize)
 {
     width = nW;
     height = nH;
@@ -14,11 +14,11 @@ dehazing::dehazing(int nW, int nH, int nBits, int nTBlockSize, float fTransInit,
     m_PreviousFlag = bPrevFlag;
     m_PostFlag = bPosFlag;
 
-    // parameters for each cost (loss cost, temporal coherence cost)
+    // Parameters for each cost (loss cost, temporal coherence cost)
     Lambda1 = fL1;
     Lambda2 = fL2;  // only used in previous mode
 
-    // block size for transmission estimation
+    // Block size for transmission estimation
     TBlockSize = nTBlockSize;
     TransInit = fTransInit;
 
@@ -26,6 +26,9 @@ dehazing::dehazing(int nW, int nH, int nBits, int nTBlockSize, float fTransInit,
     GBlockSize = nGBlockSize;
     StepSize = 2;
     GSigma = 10.f;
+
+    // Block size for air estimation
+    ABlockSize = nABlockSize;
 
     // Specify the region of atmospheric light estimation
     TopLeftX = 0;

--- a/src/DehazingCE.h
+++ b/src/DehazingCE.h
@@ -56,7 +56,7 @@ private:
     float GSigma;
 
     int ABlockSize;
-    int m_anAirlight[3];
+    int m_anAirlight[3] = { 0 };
     int m_nAirlight;
 
     // Airlight search range

--- a/src/DehazingCE.h
+++ b/src/DehazingCE.h
@@ -10,7 +10,7 @@
 class dehazing
 {
 public:
-    dehazing(int nW, int nH, int nBits, int nTBlockSize, float fTransInit, bool bPrevFlag, bool bPosFlag, float fL1, float fL2, int nGBlockSize);
+    dehazing(int nW, int nH, int nBits, int nABlockSize, int nTBlockSize, float fTransInit, bool bPrevFlag, bool bPosFlag, float fL1, float fL2, int nGBlockSize);
 
     ~dehazing();
 
@@ -55,6 +55,7 @@ private:
     int StepSize;
     float GSigma;
 
+    int ABlockSize;
     int m_anAirlight[3];
     int m_nAirlight;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,6 +169,10 @@ static void VS_CC filterCreate(const VSMap* in, VSMap* out, void* userData, VSCo
                 throw std::string("input clip and clip \"ref\" must have the same number of frames");
         }
 
+        int ABlockSize = int64ToIntS(vsapi->propGetInt(in, "air_size", 0, &err));
+        if (err)
+            ABlockSize = 200;
+
         int GBlockSize = int64ToIntS(vsapi->propGetInt(in, "guide_size", 0, &err));
         if (err)
             GBlockSize = 40;
@@ -193,7 +197,7 @@ static void VS_CC filterCreate(const VSMap* in, VSMap* out, void* userData, VSCo
         if (err)
             PostFlag = false;
 
-        d->dehazing_clip = new dehazing(width, height, bits, TBlockSize, TransInit, false, PostFlag, lamdaA, 1.f, GBlockSize);
+        d->dehazing_clip = new dehazing(width, height, bits, ABlockSize, TBlockSize, TransInit, false, PostFlag, lamdaA, 1.f, GBlockSize);
 
         //d->dehazing_clip->MakeExpLUT(); // called in NFTrsEstimationPColor(), NFTrsEstimationP()
         //d->dehazing_clip->GuideLUTMaker(); // called in FastGuideFilter()
@@ -217,6 +221,7 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit(VSConfigPlugin configFunc, VSRegiste
         "src:clip;"
         "ref:clip:opt;"
         "trans:float:opt;"
+        "air_size:int:opt;"
         "guide_size:int:opt;"
         "trans_size:int:opt;"
         "lamda:float:opt;"


### PR DESCRIPTION
I thought it would speed up, but it didn't almost.

~~* Time elapsed: 0:28.380 - 7.08243284105080928015 FPS old~~
~~* Time elapsed: 0:28.275 - 7.10862776131904450239 FPS new~~

(The test has problem...)

After all, the calculation area is small (area is 200), not the whole picture.

However, there is an interesting fact. Between last version and now, althougth the output of 8bit or 10bit is same, while the output of 16bit is different. For 16bit, the output in new verison is whitish.