### PR TITLE
Improve Github Action CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ on:
       - '**.md'
 
 env:
-  VAPOURSYNTH_VERSION: R53
+  VAPOURSYNTH_VERSION: R61
 
 jobs:
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: configure
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,15 @@ jobs:
       - name: build
         run: cmake --build build -j 2
 
+      - name: strip
+        run: strip build/libDehazingCE.so
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-vapoursynth-dehazingce
+          path: build/libDehazingCE.so
+
   build-windows:
 
     runs-on: windows-latest
@@ -66,3 +75,12 @@ jobs:
 
       - name: build
         run: cmake --build build -j 2
+
+      - name: strip
+        run: strip build/Debug/DehazingCE.dll
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-vapoursynth-dehazingce
+          path: build/Debug/DehazingCE.dll

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,11 +19,13 @@ on:
       - '**/LICENSE'
       - '**.md'
 
+  # Manual trigger
+  workflow_dispatch:
+
 env:
   VAPOURSYNTH_VERSION: R61
 
 jobs:
-
   build-linux:
 
     runs-on: ubuntu-latest
@@ -40,7 +42,7 @@ jobs:
           mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VSHelper.h src/vapoursynth/VSHelper.h
           mkdir build && cd build
           cmake -DVAPOURSYNTH_INCLUDE_DIR=../src ..
-          
+
       - name: build
         run: cmake --build build -j 2
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,8 +3,21 @@ name: CI
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '.gitignore'
+      - '.gitattributes'
+      - '.gitmodules'
+      - '**/LICENSE'
+      - '**.md'
+
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '.gitignore'
+      - '.gitattributes'
+      - '.gitmodules'
+      - '**/LICENSE'
+      - '**.md'
 
 jobs:
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,9 @@ on:
       - '**/LICENSE'
       - '**.md'
 
+env:
+  VAPOURSYNTH_VERSION: R53
+
 jobs:
 
   build:
@@ -30,11 +33,11 @@ jobs:
 
       - name: configure
         run: |
-          wget https://github.com/vapoursynth/vapoursynth/archive/refs/tags/R53.tar.gz
-          tar -xzvf R53.tar.gz vapoursynth-R53/include
+          wget https://github.com/vapoursynth/vapoursynth/archive/refs/tags/${{env.VAPOURSYNTH_VERSION}}.tar.gz
+          tar -xzvf ${{env.VAPOURSYNTH_VERSION}}.tar.gz vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include
           mkdir src/vapoursynth
-          mv vapoursynth-R53/include/VapourSynth.h src/vapoursynth/VapourSynth.h
-          mv vapoursynth-R53/include/VSHelper.h src/vapoursynth/VSHelper.h
+          mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VapourSynth.h src/vapoursynth/VapourSynth.h
+          mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VSHelper.h src/vapoursynth/VSHelper.h
           mkdir build && cd build
           cmake -DVAPOURSYNTH_INCLUDE_DIR=../src ..
           

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
 
-  build:
+  build-linux:
 
     runs-on: ubuntu-latest
 
@@ -44,3 +44,25 @@ jobs:
       - name: build
         run: cmake --build build -j 2
 
+  build-windows:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: configure
+        run:  |
+          curl -s -L https://github.com/vapoursynth/vapoursynth/archive/refs/tags/${{env.VAPOURSYNTH_VERSION}}.tar.gz -o ${{env.VAPOURSYNTH_VERSION}}.tar.gz
+          tar -xzvf ${{env.VAPOURSYNTH_VERSION}}.tar.gz vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include
+          mkdir "C:/Program Files/VapourSynth/sdk/include/vapoursynth"
+          mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VapourSynth.h "C:/Program Files/VapourSynth/sdk/include/vapoursynth/VapourSynth.h"
+          mv vapoursynth-${{env.VAPOURSYNTH_VERSION}}/include/VSHelper.h "C:/Program Files/VapourSynth/sdk/include/vapoursynth/VSHelper.h"
+          mkdir "src/vapoursynth"
+          cp "C:/Program Files/VapourSynth/sdk/include/vapoursynth/VapourSynth.h" "src/vapoursynth/VapourSynth.h"
+          cp "C:/Program Files/VapourSynth/sdk/include/vapoursynth/VSHelper.h" "src/vapoursynth/VSHelper.h"
+          mkdir build && cd build
+          cmake ..
+
+      - name: build
+        run: cmake --build build -j 2

--- a/README.md
+++ b/README.md
@@ -87,6 +87,31 @@ cmake ..
 cmake --build .
 ```
 
+### Windows and Linux using Github Actions
+
+1.[Fork this repository](https://github.com/Kiyamou/VapourSynth-DehazingCE/fork).
+
+2.Enable Github Actions on your fork: **Settings** tab -> **Actions** -> **General** -> **Allow all actions and reusable workflows** -> **Save** button.
+
+3.Edit (if necessary) the file `.github/workflows/CI.yml` on your fork modifying the environment variable VapourSynth version:
+
+```
+env:
+  VAPOURSYNTH_VERSION: <SET_YOUR_VERSION>
+```
+
+4.Go to the GitHub **Actions** tab on your fork, select **CI** workflow and press the **Run workflow** button (if you modified the `.github/workflows/CI.yml` file, a workflow will be already running and no need to run a new one).
+
+When the workflow is completed you will be able to download the artifacts generated (Windows and Linux versions) from the run.
+
+## Download Nightly Builds
+
+**GitHub Actions Artifacts ONLY can be downloaded by GitHub logged users.**
+
+Nightly builds are built automatically by GitHub Actions (GitHub's integrated CI/CD tool) every time a new commit is pushed to the _master_ branch or a pull request is created.
+
+To download the latest nightly build, go to the GitHub [Actions](https://github.com/Kiyamou/VapourSynth-DehazingCE/actions/workflows/CI.yml) tab, enter the last run of workflow **CI**, and download the artifacts generated (Windows and Linux versions) from the run.
+
 ## License
 
 [License](https://github.com/Kiyamou/VapourSynth-DehazingCE/blob/master/LICENSE) is from original source code.


### PR DESCRIPTION
With these changes, GitHub users can compile the latest version using GitHub Actions without install VapourSynth and compilation tools on their computers, getting Linux and Windows libraries with the VapourSynth version of their choice (README is updated with instructions), so it's very easy test the code with different VapourSynth versions.

* No need to compile if text files are changed
* Update actions to avoid warnings about deprecated actions
* Update to VapourSynth R61 using environment variable
* Add Windows build
* Upload compiled Linux and Windows stripped libraries
* Add manual trigger to test compilation with other branches
* Add GitHub Actions instructions in README